### PR TITLE
added comm.match.arg

### DIFF
--- a/R/comm_matcharg.r
+++ b/R/comm_matcharg.r
@@ -1,0 +1,16 @@
+comm.match.arg <- function(arg, choices, several.ok=FALSE, ..., 
+    all.rank = .SPMD.CT$print.all.rank, rank.print = .SPMD.CT$rank.source,
+    comm = .SPMD.CT$comm, mpi.finalize = .SPMD.CT$mpi.finalize,
+    quit = .SPMD.CT$quit)
+{
+  arg <- try(
+    match.arg(arg=arg, choices=choices, several.ok=several.ok), 
+    silent=TRUE
+  )
+  
+  if (inherits(arg, "try-error"))
+    comm.stop(arg, call.=FALSE, all.rank=all.rank, rank.print=rank.print, comm=comm, 
+              mpi.finalize=mpi.finalize, quit=quit)
+  
+  return(arg)
+}

--- a/man/xx_comm_match_arg.Rd
+++ b/man/xx_comm_match_arg.Rd
@@ -1,0 +1,32 @@
+\name{global match.arg}
+\alias{comm.match.arg}
+\title{ Global Argument Matching }
+\description{
+  A binding for \code{match.arg()} that uses \code{comm.stop()} rather
+  so that the error message (if there is one) is managed according
+  to the rules of \code{.SPMD.CT}.
+}
+\usage{
+  comm.match.arg(arg, choices, several.ok=FALSE, ..., 
+    all.rank = .SPMD.CT$print.all.rank, rank.print = .SPMD.CT$rank.source,
+    comm = .SPMD.CT$comm, mpi.finalize = .SPMD.CT$mpi.finalize,
+    quit = .SPMD.CT$quit)
+}
+\arguments{
+  \item{arg,choices,several.ok}{see match.arg()}
+  \item{...}{ignored.}
+  \item{all.rank}{if all ranks print (default = FALSE).}
+  \item{rank.print}{rank for printing if not all ranks print (default = 0).}
+  \item{comm}{communicator for printing (default = 1).}
+  \item{mpi.finalize}{if MPI should be shutdown.}
+  \item{quit}{if quit R when errors happen.}
+}
+\references{
+  Programming with Big Data in R Website:
+  \url{http://r-pbd.org/}
+}
+\author{
+  Wei-Chen Chen \email{wccsnow@gmail.com}, George Ostrouchov,
+  Drew Schmidt, Pragneshkumar Patel, and Hao Yu.
+}
+\keyword{utility}


### PR DESCRIPTION
Shorthand for the numerous `match.arg()` calls wrapped in `try()`/`comm.stop()` in pbdDMAT. 