### PR TITLE
hide unnecessary rlecuyer warnings on double init()

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -80,3 +80,5 @@ export(
 S3method(comm.sort, default)
 S3method(comm.sort, integer)
 S3method(comm.sort, double)
+
+export(".pbdEnv")

--- a/R/spmd_communicator.r
+++ b/R/spmd_communicator.r
@@ -78,10 +78,10 @@ spmd.init <- function(set.seed = TRUE){
     names <- as.character(0:(comm.size - 1))
     name <- as.character(comm.rank)
 
-    invisible(eval(.lec.old.kind <- RNGkind(), envir = .GlobalEnv))
-    invisible(eval(.lec.SetPackageSeed(seed), envir = .GlobalEnv))
-    invisible(eval(.lec.CreateStream(names), envir = .GlobalEnv))
-    invisible(eval(.lec.CurrentStream(name), envir = .GlobalEnv))
+    suppressWarnings(eval(.lec.old.kind <- RNGkind(), envir = .GlobalEnv))
+    suppressWarnings(eval(.lec.SetPackageSeed(seed), envir = .GlobalEnv))
+    suppressWarnings(eval(.lec.CreateStream(names), envir = .GlobalEnv))
+    suppressWarnings(eval(.lec.CurrentStream(name), envir = .GlobalEnv))
   }
 
   invisible(ret)


### PR DESCRIPTION
Fixes:

* annoying spurious warning on double `init()`
* exports the new common environment

pbdBASE and pbdDMAT each have a genv branch which syncs with pbdMPI's genv branch.  Tests are passing and pbdMPI and pbdBASE are passing `R CMD check` (dmat has a few things that will be updated momentarily), so I'd say it's all good to merge into master.