### PR TITLE
add low-level float reduce/allreduce

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2017-11-16: Ver. 0.3-4
+  * Added "spmd.allreduce.float()" and "spmd.reduce.float()".
+
 2017-09-24: Ver. 0.3-4
   * Fix man help regarding "task.pull()".
 

--- a/R/spmd_allreduce.r
+++ b/R/spmd_allreduce.r
@@ -39,6 +39,12 @@ spmd.allreduce.logical <- function(x, x.buffer,
   as.logical(ret)
 } # End of spmd.allreduce.logical().
 
+spmd.allreduce.float <- function(x, x.buffer,
+    op = .pbd_env$SPMD.CT$op, comm = .pbd_env$SPMD.CT$comm){
+  .Call("spmd_allreduce_float", x, x.buffer,
+        which(op[1] == .pbd_env$SPMD.OP), as.integer(comm),
+        PACKAGE = "pbdMPI")
+} # End of spmd.allreduce.integer().
 
 ### S4 methods.
 setGeneric(
@@ -67,4 +73,3 @@ setMethod(
   signature = signature(x = "logical", x.buffer = "logical"),
   definition = spmd.allreduce.logical
 )
-

--- a/R/spmd_reduce.r
+++ b/R/spmd_reduce.r
@@ -53,6 +53,18 @@ spmd.reduce.logical <- function(x, x.buffer, op = .pbd_env$SPMD.CT$op,
   as.logical(ret)
 } # End of spmd.reduce.logical().
 
+spmd.reduce.float <- function(x, x.buffer, op = .pbd_env$SPMD.CT$op,
+    rank.dest = .pbd_env$SPMD.CT$rank.source, comm = .pbd_env$SPMD.CT$comm){
+  ret <- .Call("spmd_reduce_float", x, x.buffer,
+               which(op[1] == .pbd_env$SPMD.OP),
+               as.integer(rank.dest), as.integer(comm),
+               PACKAGE = "pbdMPI")
+  if(spmd.comm.rank(comm) != rank.dest){
+    return(invisible())
+  }
+  ret
+} # End of spmd.reduce.integer().
+
 
 ### S4 methods.
 setGeneric(
@@ -81,4 +93,3 @@ setMethod(
   signature = signature(x = "logical", x.buffer = "logical"),
   definition = spmd.reduce.logical
 )
-

--- a/man/zz_spmd_internal.Rd
+++ b/man/zz_spmd_internal.Rd
@@ -16,6 +16,7 @@
 \alias{spmd.allreduce.integer}
 \alias{spmd.allreduce.double}
 \alias{spmd.allreduce.logical}
+\alias{spmd.allreduce.float}
 \alias{spmd.bcast.object}
 \alias{spmd.bcast.array}
 \alias{spmd.bcast.default}
@@ -84,6 +85,7 @@
 \alias{spmd.reduce.double}
 \alias{spmd.scatter.object}
 \alias{spmd.reduce.logical}
+\alias{spmd.reduce.float}
 \alias{spmd.scatter.array}
 \alias{spmd.scatter.default}
 \alias{spmd.scatterv.default}

--- a/src/spmd.h
+++ b/src/spmd.h
@@ -165,11 +165,15 @@ SEXP spmd_allreduce_integer(SEXP R_send_data, SEXP R_recv_data,
 		SEXP R_op, SEXP R_comm);
 SEXP spmd_allreduce_double(SEXP R_send_data, SEXP R_recv_data,
 		SEXP R_op, SEXP R_comm);
+SEXP spmd_allreduce_float(SEXP R_send_data, SEXP R_recv_data,
+		SEXP R_op, SEXP R_comm);
 
 /* In file "spmd_reduce.c". */
 SEXP spmd_reduce_integer(SEXP R_send_data, SEXP R_recv_data,
 		SEXP R_op, SEXP R_rank_dest, SEXP R_comm);
 SEXP spmd_reduce_double(SEXP R_send_data, SEXP R_recv_data,
+		SEXP R_op, SEXP R_rank_dest, SEXP R_comm);
+SEXP spmd_reduce_float(SEXP R_send_data, SEXP R_recv_data,
 		SEXP R_op, SEXP R_rank_dest, SEXP R_comm);
 
 /* In file "spmd_bcast.c". */
@@ -242,4 +246,3 @@ SEXP AsInt(int x);
 int spmd_errhandler(int error_code);
 
 #endif
-

--- a/src/spmd_allreduce.c
+++ b/src/spmd_allreduce.c
@@ -102,3 +102,54 @@ SEXP spmd_allreduce_double(SEXP R_send_data, SEXP R_recv_data,
 #endif
 	return(R_recv_data);
 } /* End of spmd_allreduce_double(). */
+
+SEXP spmd_allreduce_float(SEXP R_send_data, SEXP R_recv_data,
+		SEXP R_op, SEXP R_comm){
+#ifdef LONG_VECTOR_SUPPORT
+	float *C_send_data = (float*) INTEGER(R_send_data),
+	    *C_recv_data = (float*) INTEGER(R_recv_data);
+	R_xlen_t C_length_send_data = XLENGTH(R_send_data);
+	int C_op = INTEGER(R_op)[0],
+	    C_comm = INTEGER(R_comm)[0];
+	#if (MPI_LONG_DEBUG & 1) == 1
+		int C_comm_rank;
+		MPI_Comm_rank(comm[C_comm], &C_comm_rank);
+	#endif
+
+	/* Loop through all. */
+	while(C_length_send_data > SPMD_SHORT_LEN_MAX){
+		#if (MPI_LONG_DEBUG & 1) == 1
+			if(C_comm_rank == 0){
+				Rprintf("C_length_send_data: %ld\n",
+					C_length_send_data);
+			}
+		#endif
+
+		spmd_errhandler(MPI_Allreduce(C_send_data,
+			C_recv_data, SPMD_SHORT_LEN_MAX,
+			MPI_FLOAT, SPMD_OP[C_op], comm[C_comm]));
+		C_send_data = C_send_data + SPMD_SHORT_LEN_MAX;
+		C_recv_data = C_recv_data + SPMD_SHORT_LEN_MAX;
+		C_length_send_data = C_length_send_data - SPMD_SHORT_LEN_MAX;
+	}
+
+	/* Remainder. */
+	if(C_length_send_data > 0){
+		#if (MPI_LONG_DEBUG & 1) == 1
+			if(C_comm_rank == 0){
+				Rprintf("C_length_send_data: %ld\n",
+					C_length_send_data);
+			}
+		#endif
+
+		spmd_errhandler(MPI_Allreduce(C_send_data,
+			C_recv_data, (int) C_length_send_data,
+			MPI_FLOAT, SPMD_OP[C_op], comm[C_comm]));
+	}
+#else
+	spmd_errhandler(MPI_Allreduce(INTEGER(R_send_data),
+		INTEGER(R_recv_data), LENGTH(R_send_data), MPI_FLOAT,
+		SPMD_OP[INTEGER(R_op)[0]], comm[INTEGER(R_comm)[0]]));
+#endif
+	return(R_recv_data);
+} /* End of spmd_allreduce_float(). */

--- a/src/spmd_reduce.c
+++ b/src/spmd_reduce.c
@@ -105,3 +105,54 @@ SEXP spmd_reduce_double(SEXP R_send_data, SEXP R_recv_data,
 	return(R_recv_data);
 } /* End of spmd_reduce_double(). */
 
+SEXP spmd_reduce_float(SEXP R_send_data, SEXP R_recv_data,
+		SEXP R_op, SEXP R_rank_dest, SEXP R_comm){
+#ifdef LONG_VECTOR_SUPPORT
+	float *C_send_data = (float*) INTEGER(R_send_data),
+	    *C_recv_data = (float*) INTEGER(R_recv_data);
+	R_xlen_t C_length_send_data = XLENGTH(R_send_data);
+	int C_op = INTEGER(R_op)[0],
+	    C_rank_dest = INTEGER(R_rank_dest)[0],
+	    C_comm = INTEGER(R_comm)[0];
+	#if (MPI_LONG_DEBUG & 1) == 1
+		int C_comm_rank;
+		MPI_Comm_rank(comm[C_comm], &C_comm_rank);
+	#endif
+
+	/* Loop through all. */
+	while(C_length_send_data > SPMD_SHORT_LEN_MAX){
+		#if (MPI_LONG_DEBUG & 1) == 1
+			if(C_comm_rank == C_rank_dest){
+				Rprintf("C_length_send_data: %ld\n",
+					C_length_send_data);
+			}
+		#endif
+
+		spmd_errhandler(MPI_Reduce(C_send_data, C_recv_data,
+			SPMD_SHORT_LEN_MAX, MPI_FLOAT, SPMD_OP[C_op],
+			C_rank_dest, comm[C_comm]));
+		C_send_data = C_send_data + SPMD_SHORT_LEN_MAX;
+		C_recv_data = C_recv_data + SPMD_SHORT_LEN_MAX;
+		C_length_send_data = C_length_send_data - SPMD_SHORT_LEN_MAX;
+	}
+
+	/* Remainder. */
+	if(C_length_send_data > 0){
+		#if (MPI_LONG_DEBUG & 1) == 1
+			if(C_comm_rank == C_rank_dest){
+				Rprintf("C_length_send_data: %ld\n",
+					C_length_send_data);
+			}
+		#endif
+
+		spmd_errhandler(MPI_Reduce(C_send_data, C_recv_data,
+			(int) C_length_send_data, MPI_FLOAT, SPMD_OP[C_op],
+			C_rank_dest, comm[C_comm]));
+	}
+#else
+	spmd_errhandler(MPI_Reduce(INTEGER(R_send_data), INTEGER(R_recv_data),
+		LENGTH(R_send_data), MPI_FLOAT, SPMD_OP[INTEGER(R_op)[0]],
+		INTEGER(R_rank_dest)[0], comm[INTEGER(R_comm)[0]]));
+#endif
+	return(R_recv_data);
+} /* End of spmd_reduce_float(). */

--- a/src/zzz.c
+++ b/src/zzz.c
@@ -102,10 +102,12 @@ static const R_CallMethodDef callMethods[] = {
 	/* In file "spmd_allreduce.c". */
 	{"spmd_allreduce_integer", (DL_FUNC) &spmd_allreduce_integer, 4},
 	{"spmd_allreduce_double", (DL_FUNC) &spmd_allreduce_double, 4},
+	{"spmd_allreduce_float", (DL_FUNC) &spmd_allreduce_float, 4},
 
 	/* In file "spmd_reduce.c". */
 	{"spmd_reduce_integer", (DL_FUNC) &spmd_reduce_integer, 5},
 	{"spmd_reduce_double", (DL_FUNC) &spmd_reduce_double, 5},
+	{"spmd_reduce_float", (DL_FUNC) &spmd_reduce_float, 5},
 
 	/* In file "spmd_bcast.c". */
 	{"spmd_bcast_integer", (DL_FUNC) &spmd_bcast_integer, 3},


### PR DESCRIPTION
Adds low-level reduce/allreduce functionality for [32-bit floats](https://github.com/wrathematics/float) (stored as ints). Passes R CMD check with the latest version of R-devel.

Example usage:

```r
suppressMessages(library(float, quietly=TRUE))
suppressMessages(library(pbdMPI, quietly=TRUE))

s = fl(1:3)
x = float32(spmd.allreduce.float(s@Data, integer(length(s))))
comm.print(x, all.rank=TRUE)

finalize()
```

Output:

```
COMM.RANK = 0
# A float32 vector: 3
[1] 2 4 6
COMM.RANK = 1
# A float32 vector: 3
[1] 2 4 6
```