### PR TITLE
Added comm.localrank()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2017-12-12: Ver. 0.3-4
+  * Added comm.localrank().
+
 2017-12-02: Ver. 0.3-4
   * Fix a "spmd.gatherv_array()" bug.
 

--- a/R/spmd_communicator.r
+++ b/R/spmd_communicator.r
@@ -23,6 +23,12 @@ spmd.comm.rank <- function(comm = .pbd_env$SPMD.CT$comm){
 
 comm.rank <- spmd.comm.rank
 
+spmd.comm.localrank <- function(comm = .pbd_env$SPMD.CT$comm){
+  .Call("spmd_comm_localrank", as.integer(comm), PACKAGE = "pbdMPI")
+} # End of spmd.comm.localrank().
+
+comm.localrank <- spmd.comm.localrank
+
 spmd.comm.size <- function(comm = .pbd_env$SPMD.CT$comm){
   tmp <- .Call("spmd_comm_is_null", as.integer(comm), PACKAGE = "pbdMPI")
 

--- a/man/cc_comm.Rd
+++ b/man/cc_comm.Rd
@@ -2,6 +2,7 @@
 \alias{barrier}
 \alias{comm.is.null}
 \alias{comm.rank}
+\alias{comm.localrank}
 \alias{comm.size}
 \alias{comm.dup}
 \alias{comm.free}
@@ -31,6 +32,7 @@
 barrier(comm = .pbd_env$SPMD.CT$comm)
 comm.is.null(comm = .pbd_env$SPMD.CT$comm)
 comm.rank(comm = .pbd_env$SPMD.CT$comm)
+comm.localrank(comm = .pbd_env$SPMD.CT$comm)
 comm.size(comm = .pbd_env$SPMD.CT$comm)
 comm.dup(comm, newcomm)
 comm.free(comm = .pbd_env$SPMD.CT$comm)

--- a/man/zz_spmd_internal.Rd
+++ b/man/zz_spmd_internal.Rd
@@ -30,6 +30,7 @@
 \alias{spmd.comm.set.errhandler}
 \alias{spmd.comm.is.null}
 \alias{spmd.comm.rank}
+\alias{spmd.comm.localrank}
 \alias{spmd.comm.size}
 \alias{spmd.comm.dup}
 \alias{spmd.comm.free}

--- a/src/pkg_global.h
+++ b/src/pkg_global.h
@@ -18,6 +18,7 @@
 
 /* Declared in "Rmpi.c", "spmd.c", or similar main c functions. */
 extern MPI_Comm *comm;
+extern MPI_Comm localcomm;
 extern MPI_Status *status;
 extern MPI_Datatype *datatype;
 extern MPI_Info *info;
@@ -55,4 +56,3 @@ SEXP pkg_dlclose();
 #define CHARPT(x,i)	((char*)CHAR(STRING_ELT(x,i)))
 
 #endif
-

--- a/src/spmd.c
+++ b/src/spmd.c
@@ -1,6 +1,7 @@
 #include "spmd.h"
 
 MPI_Comm *comm = NULL;
+MPI_Comm localcomm = MPI_COMM_NULL;
 MPI_Status *status = NULL;
 MPI_Datatype *datatype = NULL;
 MPI_Info *info = NULL;
@@ -41,6 +42,11 @@ SEXP spmd_initialize(){
 			comm[i] = MPI_COMM_NULL;
 		}
 	}
+#if MPI_VERSION >= 3
+	if (localcomm == MPI_COMM_NULL){
+		MPI_Comm_split_type(comm[0], MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &localcomm);
+	}
+#endif
 	if(status == NULL){
 		status = (MPI_Status *) Calloc(STATUS_MAXSIZE, MPI_Status); 
 	}
@@ -125,4 +131,3 @@ SEXP spmd_universe_size(){
 	}
 } /* End of spmd_universe_size(). */
 #endif
-

--- a/src/spmd.h
+++ b/src/spmd.h
@@ -41,6 +41,7 @@ SEXP spmd_barrier(SEXP R_comm);
 SEXP spmd_comm_is_null(SEXP R_comm);
 SEXP spmd_comm_size(SEXP R_comm);
 SEXP spmd_comm_rank(SEXP R_comm);
+SEXP spmd_comm_localrank(SEXP R_comm);
 SEXP spmd_comm_dup(SEXP R_comm, SEXP R_newcomm);
 SEXP spmd_comm_free(SEXP R_comm);
 SEXP spmd_comm_set_errhandler(SEXP R_comm);

--- a/src/spmd_communicator.c
+++ b/src/spmd_communicator.c
@@ -23,6 +23,26 @@ SEXP spmd_comm_rank(SEXP R_comm){
 	return(AsInt(rank));
 } /* End of spmd_comm_rank(). */
 
+SEXP spmd_comm_localrank(SEXP R_comm){
+#if MPI_VERSION >= 3
+	MPI_Comm tmp_comm;
+	int localrank;
+	
+	if (INTEGER(R_comm)[0] == 0){
+		tmp_comm = localcomm;
+	}
+	else {
+		MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &tmp_comm);
+	}
+	
+	spmd_errhandler(MPI_Comm_rank(tmp_comm, &localrank));
+	
+	return AsInt(localrank);
+#else
+	error("only MPI >= 3 supported\n");
+#endif
+} /* End of spmd_comm_localrank(). */
+
 SEXP spmd_comm_dup(SEXP R_comm, SEXP R_newcomm){
 	int commn = INTEGER(R_comm)[0], newcommn = INTEGER(R_newcomm)[0];
 	if(commn == 0){
@@ -202,4 +222,3 @@ SEXP spmd_intercomm_create(SEXP R_local_comm, SEXP R_local_leader,
 SEXP spmd_comm_c2f(SEXP R_comm){
 	return(AsInt((int) MPI_Comm_c2f(comm[INTEGER(R_comm)[0]])));
 } /* End of spmd_comm_c2f(). */
-

--- a/src/spmd_communicator_spawn.c
+++ b/src/spmd_communicator_spawn.c
@@ -1,8 +1,8 @@
 #include "spmd.h"
 
-#ifdef MPI2
 SEXP spmd_comm_spawn(SEXP R_worker, SEXP R_workerargv, SEXP R_n_workers,
 		SEXP R_info, SEXP R_rank_source, SEXP R_intercomm){
+#ifdef MPI2
 	int i, n_workers = INTEGER(R_n_workers)[0], len = LENGTH(R_workerargv);
 	int infon = INTEGER(R_info)[0], rank_source = INTEGER(R_rank_source)[0];
 	int intercommn = INTEGER(R_intercomm)[0], *worker_errcodes, realns;
@@ -29,10 +29,13 @@ SEXP spmd_comm_spawn(SEXP R_worker, SEXP R_workerargv, SEXP R_n_workers,
 		}
 	}
 
-        Free(worker_errcodes);
+	Free(worker_errcodes);
 
 	Rprintf("\t%d workers are spawned successfully. %d failed.\n",
 		realns, n_workers - realns);
 	return AsInt(realns);
-} /* End of spmd_comm_spawn(). */
+#else
+	error("only MPI >= 2 supported\n");
+	return R_NilValue;
 #endif
+} /* End of spmd_comm_spawn(). */

--- a/src/zzz.c
+++ b/src/zzz.c
@@ -22,6 +22,7 @@ static const R_CallMethodDef callMethods[] = {
 	{"spmd_comm_is_null", (DL_FUNC) &spmd_comm_is_null, 1},
 	{"spmd_comm_size", (DL_FUNC) &spmd_comm_size, 1},
 	{"spmd_comm_rank", (DL_FUNC) &spmd_comm_rank, 1},
+	{"spmd_comm_localrank", (DL_FUNC) &spmd_comm_localrank, 1},
 	{"spmd_comm_dup", (DL_FUNC) &spmd_comm_dup, 2},
 	{"spmd_comm_free", (DL_FUNC) &spmd_comm_free, 1},
 	{"spmd_comm_set_errhandler", (DL_FUNC) &spmd_comm_set_errhandler, 1},
@@ -42,9 +43,8 @@ static const R_CallMethodDef callMethods[] = {
 	{"spmd_comm_c2f", (DL_FUNC) &spmd_comm_c2f, 1},
 
 	/* In file "spmd_communicator_spawn.c". */
-  #ifdef MPI2
 	{"spmd_comm_spawn", (DL_FUNC) &spmd_comm_spawn, 6},
-  #endif
+	{"spmd_comm_spawn", (DL_FUNC) &spmd_comm_spawn, 6},
 
 	/* In file "spmd_allgather.c". */
 	{"spmd_allgather_integer", (DL_FUNC) &spmd_allgather_integer, 3},


### PR DESCRIPTION
As discussed on slack, this implements a `comm.localrank()` via the MPI 3 function `MPI_Comm_split_type()`. At the moment, it automatically does this on init for `MPI_COMM_WORLD`, and will look it up on the fly for other communicators. I didn't make it automatic since I think carrying around a bunch of communicators created via split has performance implications.  Don't feel compelled to merge if you want this done differently.

Example use:

```r
suppressMessages(library(pbdMPI, quietly=TRUE))

size = comm.size()
for (rank in 0:(size-1)){
  if (rank == comm.rank()){
    print(paste0("Hello from rank ", rank, " (local rank ", comm.localrank(), ") of ", size))
  }
}

finalize()
```

Output:

```
mpirun -n 4 -npernode 2 Rscript hw.r 
[1] "Hello from rank 0 (local rank 0) of 4"
[1] "Hello from rank 1 (local rank 1) of 4"
[1] "Hello from rank 2 (local rank 0) of 4"
[1] "Hello from rank 3 (local rank 1) of 4"
```