### PR TITLE
first pass at send/recv fix for atomics

### DIFF
--- a/R/000_globalVariables.r
+++ b/R/000_globalVariables.r
@@ -9,3 +9,8 @@
 if(getRversion() >= "2.15.1"){
   utils::globalVariables(c(".pbd_env"))
 }
+
+RTYPE_INTEGER = 1L
+RTYPE_DOUBLE = 2L
+RTYPE_RAW = 3L
+RTYPE_OTHER = 4L

--- a/R/spmd_recv.r
+++ b/R/spmd_recv.r
@@ -1,17 +1,43 @@
+### 
+recv.check.type <- function(rank.source, tag, comm, status){
+  spmd.recv.integer(x.buffer = integer(1), rank.source = rank.source, tag = tag,
+    comm = comm, status = status)
+}
+
+
 ### S4 functions.
 
 ### Default method.
 spmd.recv.default <- function(x.buffer = NULL,
     rank.source = .pbd_env$SPMD.CT$rank.source, tag = .pbd_env$SPMD.CT$tag,
     comm = .pbd_env$SPMD.CT$comm, status = .pbd_env$SPMD.CT$status){
+  type <- recv.check.type(rank.source = rank.source, tag = tag, comm = comm,
+      status = status)
   spmd.probe(rank.source, tag, comm, status)
   source.tag <- spmd.get.sourcetag(status)
-  total.length <- spmd.get.count(4L, status)
-  unserialize(spmd.recv.raw(raw(total.length),
-                            rank.source = source.tag[1],
-                            tag = source.tag[2],
-                            comm = comm,
-                            status = status))
+  total.length <- spmd.get.count(type, status)
+  if (type == RTYPE_INTEGER){
+    buf <- integer(total.length)
+    recv.fun <- spmd.recv.integer
+  } else if (type == RTYPE_DOUBLE){
+    buf <- double(total.length)
+    recv.fun <- spmd.recv.double
+  } else if (type == RTYPE_RAW || type == RTYPE_OTHER){
+    buf <- raw(total.length)
+    recv.fun <- spmd.recv.raw
+  }
+  
+  ret <- recv.fun(buf,
+    rank.source = source.tag[1],
+    tag = source.tag[2],
+    comm = comm,
+    status = status)
+  
+  if (type == RTYPE_OTHER){
+    unserialize(ret)
+  } else{
+    ret
+  }
 } # End of spmd.recv.default().
 
 
@@ -68,4 +94,3 @@ setMethod(
   signature = signature(x.buffer = "raw"),
   definition = spmd.recv.raw
 )
-

--- a/R/spmd_send.r
+++ b/R/spmd_send.r
@@ -1,11 +1,38 @@
+### 
+send.check.type <- function(x, rank.dest, tag, comm){
+  if (!is.matrix(x) && (is.integer(x) || is.double(x) || is.raw(x))){
+    if (is.integer(x)){
+      type <- RTYPE_INTEGER
+    } else if (is.double(x)){
+      type <- RTYPE_DOUBLE
+    } else{
+      type <- RTYPE_RAW
+    }
+  } else{
+    type <- RTYPE_OTHER
+  }
+  
+  spmd.send.integer(type, rank.dest = rank.dest, tag = tag, comm = comm)
+  return(type)
+}
+
+
 ### S4 functions.
 
 ### Default method.
 spmd.send.default <- function(x,
     rank.dest = .pbd_env$SPMD.CT$rank.dest, tag = .pbd_env$SPMD.CT$tag,
     comm = .pbd_env$SPMD.CT$comm){
-  spmd.send.raw(serialize(x, NULL), rank.dest = rank.dest,
-                tag = tag, comm = comm)
+  type <- send.check.type(x = x, rank.dest = rank.dest, tag = tag, comm = comm)
+  if (type == RTYPE_INTEGER){
+    spmd.send.integer(x, rank.dest = rank.dest, tag = tag, comm = comm)
+  } else if (type == RTYPE_DOUBLE){
+    spmd.send.double(x, rank.dest = rank.dest, tag = tag, comm = comm)
+  } else if (type == RTYPE_RAW){
+    spmd.send.raw(x, rank.dest = rank.dest, tag = tag, comm = comm)
+  } else{
+    spmd.send.raw(serialize(x, NULL), rank.dest = rank.dest, tag = tag, comm = comm)
+  }
   invisible()
 } # End of spmd.send.default().
 
@@ -48,19 +75,3 @@ setMethod(
   signature = signature(x = "ANY"),
   definition = spmd.send.default
 )
-setMethod(
-  f = "send",
-  signature = signature(x = "integer"),
-  definition = spmd.send.integer
-)
-setMethod(
-  f = "send",
-  signature = signature(x = "numeric"),
-  definition = spmd.send.double
-)
-setMethod(
-  f = "send",
-  signature = signature(x = "raw"),
-  definition = spmd.send.raw
-)
-


### PR DESCRIPTION
This is a first pass attempt at resolving the unexpected `send()`/`recv()` behavior. I didn't deal with `isend()`/`irecv()` yet because I'm not sure if this is completely correct. The issue is [line 18 of spmd_recv.r](https://github.com/wrathematics/pbdMPI/blob/master/R/spmd_recv.r#L18) which uses a "type" integer (defined here https://github.com/wrathematics/pbdMPI/blob/master/R/000_globalVariables.r#L13-L16) to somewhat match `SPMD_DT` defined in spmd_constant.h. I'm not sure about the char/raw clash, or if it even matters.

Here's a test script:

```r
suppressMessages(library(pbdMPI))

if (comm.rank() == 0){
  send(pi, rank.dest=1)
} else {
  print(recv(rank.source=0))
}

finalize()
```