### PR TITLE
Disable staged installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports: rlecuyer, float
 Enhances: pbdPROF, pbdZMQ
 LazyLoad: yes
 LazyData: yes
+StagedInstall: no
 Description: An efficient interface to MPI by utilizing S4
         classes and methods with a focus on Single Program/Multiple Data
         ('SPMD')


### PR DESCRIPTION
We are trying to upgrade the Windows toolchain on CRAN and the pbdBASE package [fails to compile on Windows](https://cran.r-project.org/web/checks/check_results_pbdBASE.html). The end of the fail log shows this:

```
gcc.exe: error: d:/Rcompile/CRANpkg/lib/4.0v3/00LOCK-pbdMPI/00new/pbdMPI/libs/x64/libmsmpi64.a: No such file or directory
```

Note how it is looking for a dependency in the temporary staged installation path `00LOCK-pbdMPI` rather than the real installation path. One easy solution is to disable staged installation for pbdMPI. Or perhaps you can think of another solution.

Can you please submit a fix to CRAN asap?

See bug report here: https://github.com/r-windows/checks/issues/85

